### PR TITLE
[TROUP-14] Remove JvmName annotation

### DIFF
--- a/troupe/src/commonMain/kotlin/com/saintpatrck/logging/troupe/Troupe.kt
+++ b/troupe/src/commonMain/kotlin/com/saintpatrck/logging/troupe/Troupe.kt
@@ -1,5 +1,3 @@
-@file:JvmName("Troupe")
-
 package com.saintpatrck.logging.troupe
 
 import kotlin.concurrent.Volatile


### PR DESCRIPTION
## Issue Description:
Build errors are occurring due to duplicate JVM class names. This is caused due to an unnecessary `@JvmName` annotation in the main Troupe file.

## Fix:
Remove `@JvmName` from `Troupe.kts`.

## Related Issue(s):
TROUP-14