### PR TITLE
[TROUP-23] Rename root project

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,5 +15,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "troupe"
+rootProject.name = "troupe-logging"
 include(":troupe")


### PR DESCRIPTION
## Summary:
Project was encountering a build failure during test execution with the following error:

```
FAILURE: Build failed with an exception.

* What went wrong:
org.gradle.api.internal.catalog.GeneratedClassCompilationException: Unable to compile generated sources:
  - File RootProjectAccessor.java, line: 29, method getTroupe() is already defined in class org.gradle.accessors.dm.RootProjectAccessor
> Unable to compile generated sources:
    - File RootProjectAccessor.java, line: 29, method getTroupe() is already defined in class org.gradle.accessors.dm.RootProjectAccessor
```

Build failure is the result of root project and submodule having the same name.

## Fix:
Declare `rootProject.name = "troupe-logging"` to prevent naming conflicts.