### PR TITLE
[TROUP-25] Publish to GitHub package repository

### DIFF
--- a/troupe/troupe.podspec
+++ b/troupe/troupe.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'troupe'
-    spec.version                  = '1.0.0'
+    spec.version                  = '0.0.1'
     spec.homepage                 = 'https://github.com/saintpatrck/troupe'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''
     spec.license                  = ''
-    spec.summary                  = 'Timber style logging for KMP'
+    spec.summary                  = 'Timber style logging for KMP projects'
     spec.vendored_frameworks      = 'build/cocoapods/framework/troupe.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target = '16.0'


### PR DESCRIPTION
This commit introduces the necessary configurations for publishing the Troupe library to GitHub Packages.

## Changes Made:

- Adds the `maven-publish` plugin to the project.
- Sets the project version to `0.0.1`.
- Configures the Android target to publish library variants.
- Updates the Cocoapods summary to be more descriptive.
- Adds publishing configuration to publish to GitHub Packages using credentials from `local.properties` or environment variables.
- Updates the podspec version to match the project version and updates the summary.