### PR TITLE
[TROUP-26] Upgrade Gradle Wrapper to 8.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Feb 16 20:33:09 EST 2024
+#Mon Oct 28 23:22:45 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Tracking
Completes TROUP-26

## Purpose
Update the Gradle Wrapper to use Gradle version 8.9.
