### PR TITLE
[TROUP-18] Configure Renovate Bot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,50 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    ':combinePatchMinorReleases',
+    ':separateMajorReleases',
+    'config:recommended',
+    'config:best-practices',
+  ],
+  baseBranches: [
+    'main',
+  ],
+  packageRules: [
+    {
+      description: 'Group Gradle minor and patch updates',
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+      matchManagers: [
+        'gradle',
+      ],
+      groupName: 'gradle minor',
+    },
+    {
+      description: 'Group GitHub Action minor and patch updates',
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+      matchManagers: [
+        'github-actions',
+      ],
+      groupName: 'github actions',
+    },
+    {
+      description: 'Group CircleCI minor and patch updates',
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+      matchManagers: [
+        'circleci',
+      ]
+    }
+  ],
+  rebaseWhen: "auto",
+  rollbackPrs: true,
+  dependencyDashboard: true,
+  dependencyDashboardAutoclose: true,
+}


### PR DESCRIPTION
## Tracking
TROUP-18

## Objective
This commit introduces a Renovate Bot configuration file to automate dependency updates.

The configuration:

- Enables grouping of minor and patch updates for Gradle, GitHub Actions, and CircleCI.
- Sets the base branch for updates to 'main'.
- Adopts recommended and best-practice configurations.
- Enables automatic rebasing, rollback PRs, and the dependency dashboard.