### PR TITLE
Add .kotlin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ captures
 .cxx
 local.properties
 xcuserdata
+/.kotlin/


### PR DESCRIPTION
## Objective

Added `.kotlin` directory to `.gitignore` to prevent IDE specific or cached files from being committed.