### PR TITLE
[TROUP-28] Group CircleCI updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,7 +40,8 @@
       ],
       matchManagers: [
         'circleci',
-      ]
+      ],
+      groupName: 'circleci minor'
     }
   ],
   rebaseWhen: "auto",


### PR DESCRIPTION
## Tracking
TROUP-28

## Objective

Group CircleCI dependency updates under a single group named "circleci minor". This improves the organization and clarity of Renovate updates.