### PR TITLE
[TROUP-28] Add renovate/config to baseBranches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
   ],
   baseBranches: [
     'main',
+    'renovate/config',
   ],
   packageRules: [
     {


### PR DESCRIPTION
## Tracking

TROUP-28

## Objective

Added `renovate/config` to the list of base branches for testing Renovate config changes.