### PR TITLE
[TROUP-28] Merge Renovate base branch configs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,43 +4,44 @@
     ':combinePatchMinorReleases',
     ':separateMajorReleases',
     'config:recommended',
-    'config:best-practices',
+    'config:best-practices'
   ],
   baseBranches: [
     'main',
-    'renovate/config',
+    'renovate/config'
   ],
+  useBaseBranchConfig: "merge",
   packageRules: [
     {
       description: 'Group Gradle minor and patch updates',
       matchUpdateTypes: [
         'minor',
-        'patch',
+        'patch'
       ],
       matchManagers: [
-        'gradle',
+        'gradle'
       ],
-      groupName: 'gradle minor',
+      groupName: 'gradle minor'
     },
     {
       description: 'Group GitHub Action minor and patch updates',
       matchUpdateTypes: [
         'minor',
-        'patch',
+        'patch'
       ],
       matchManagers: [
-        'github-actions',
+        'github-actions'
       ],
-      groupName: 'github actions',
+      groupName: 'github actions'
     },
     {
       description: 'Group CircleCI minor and patch updates',
       matchUpdateTypes: [
         'minor',
-        'patch',
+        'patch'
       ],
       matchManagers: [
-        'circleci',
+        'circleci'
       ],
       groupName: 'circleci minor'
     }
@@ -48,5 +49,5 @@
   rebaseWhen: "auto",
   rollbackPrs: true,
   dependencyDashboard: true,
-  dependencyDashboardAutoclose: true,
+  dependencyDashboardAutoclose: true
 }


### PR DESCRIPTION
## Tracking

TROUP-28

## Objective

Merge the Renovate configs from all base branches. This allows for testing of config changes on alternate base branches.