### PR TITLE
[TROUP-28] Remove renovate/config from baseBranches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,6 @@
   ],
   baseBranches: [
     'main',
-    'renovate/config'
   ],
   useBaseBranchConfig: "merge",
   packageRules: [


### PR DESCRIPTION
## Tracking

TROUP-28

## Objective

Remove `renovate/config` from the list of base branches in the Renovate configuration. This ensures that Renovate only targets the `main` branch for dependency updates.