### PR TITLE
[TROUP-29] Add codecov orb to workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ jobs:
       - store_test_results:
           path: ./troupe/build/test-results/testDebugUnitTest
 
+      - codecov/upload
+
       - android/save_gradle_cache
 
       - android/save_build_cache


### PR DESCRIPTION
## Tracking

TROUP-29

## Objective

Added a step to upload code coverage reports to Codecov using the codecov orb in the CircleCI workflow. This will allow for tracking and monitoring of code coverage changes over time.