### PR TITLE
[TROUP-30] Add kover code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           find_args: . -name "build.gradle*" -o -name "settings.gradle*" -o -name "libs.versions.toml"
 
       - android/run_tests:
-          test_command: ./gradlew lint testDebug --continue
+          test_command: ./gradlew check
 
       - run:
           name: Assemble release build
@@ -49,7 +49,8 @@ jobs:
       - store_test_results:
           path: ./troupe/build/test-results/testDebugUnitTest
 
-      - codecov/upload
+      - codecov/upload:
+          files: troupe/build/reports/kover/report.xml
 
       - android/save_gradle_cache
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.androidLibrary).apply(false)
     alias(libs.plugins.kotlinMultiplatform).apply(false)
     alias(libs.plugins.kotlinCocoapods).apply(false)
+    alias(libs.plugins.kover).apply(false)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ jvm-target = "17"
 jvm-toolchain = "17"
 
 kotlin = "2.0.21"
-
+kover = "0.9.0-RC"
 mockK = "1.13.13"
 
 truth = "1.4.4"
@@ -37,6 +37,7 @@ truth = { module = "com.google.truth:truth", version.ref = "truth" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 
 [bundles]
 android-instrumentedTest = [

--- a/troupe/build.gradle.kts
+++ b/troupe/build.gradle.kts
@@ -1,10 +1,20 @@
 import org.jetbrains.kotlin.konan.properties.loadProperties
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kover)
     id("maven-publish")
+}
+
+val localProperties: Properties? by lazy {
+    try {
+        loadProperties("local.properties")
+    } catch (e: Throwable) {
+        null
+    }
 }
 
 group = "com.saintpatrck.logging"
@@ -73,10 +83,27 @@ android {
     }
 }
 
-val localProperties = try {
-    loadProperties("local.properties")
-} catch (e: Throwable) {
-    null
+kover {
+    currentProject {
+        sources {
+            excludeJava = true
+        }
+    }
+    reports {
+        filters {
+            excludes {
+                androidGeneratedClasses()
+            }
+        }
+        total {
+            xml {
+                onCheck.set(true)
+            }
+            html {
+                onCheck.set(true)
+            }
+        }
+    }
 }
 
 configure<PublishingExtension> {

--- a/troupe/troupe.podspec
+++ b/troupe/troupe.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
     spec.summary                  = 'Timber style logging for KMP projects'
     spec.vendored_frameworks      = 'build/cocoapods/framework/troupe.framework'
     spec.libraries                = 'c++'
-    spec.ios.deployment_target = '16.0'
+    spec.ios.deployment_target    = '16.0'
                 
                 
     if !Dir.exist?('build/cocoapods/framework/troupe.framework') || Dir.empty?('build/cocoapods/framework/troupe.framework')
@@ -21,6 +21,10 @@ Pod::Spec.new do |spec|
 
         Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
     end
+                
+    spec.xcconfig = {
+        'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO',
+    }
                 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':troupe',


### PR DESCRIPTION
## Tracking

TROUP-30

## Objective

Adds kover code coverage support to the project.

This includes:

- Adding the kover plugin and dependency to the build.
- Updating the build configuration to generate coverage reports.
- Updating the podspec to disable user script sandboxing.
- Updating the CircleCI configuration to run the coverage task.