### PR TITLE
[TROUP-31] Publish Gradle plugin to GitHub Packages

### DIFF
--- a/.github/workflows/publish-gpr.yml
+++ b/.github/workflows/publish-gpr.yml
@@ -1,0 +1,26 @@
+name: Publish to GitHub Packages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-gpr:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up JDK
+        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Publish to GitHub Packages
+        env:
+          GPR_USERNAME: ${{ secrets.GPR_USERNAME }}
+          GPR_PASSWORD: ${{ secrets.GPR_PASSWORD }}
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository


### PR DESCRIPTION
## Tracking

TROUP-31

## Objective

Introduce a new workflow to automatically build and publish the Gradle plugin to GitHub Packages.

The workflow runs on macOS latest and uses actions to checkout code, set up JDK 17, build the project, and publish to GitHub Packages using provided credentials.