### PR TITLE
[TROUP-33] Publish Troupe artifacts to local maven repo during CI

### DIFF
--- a/.github/workflows/publish-gpr.yml
+++ b/.github/workflows/publish-gpr.yml
@@ -29,7 +29,14 @@ jobs:
       - name: Build
         run: ./gradlew build
 
-      - name: Publish to GitHub Packages
+      - name: Publish to local maven repo
+        run: |
+          ./gradlew publishAllPublicationsToProjectLocalRepository
+
+      - name: Upload artifacts to action summary
+        run: ./gradlew archiveAllPublicationsFromProjectLocalRepository
+
+      - name: Publish artifacts to GitHub Packages
         env:
           GPR_USERNAME: ${{ secrets.GPR_USERNAME }}
           GPR_PASSWORD: ${{ secrets.GPR_PASSWORD }}

--- a/troupe/build.gradle.kts
+++ b/troupe/build.gradle.kts
@@ -120,10 +120,15 @@ configure<PublishingExtension> {
                         ?: System.getenv("GPR_PASSWORD")?.takeUnless { it.isEmpty() }
             }
         }
-    }
-    publications {
-        register<MavenPublication>(name = "Troupe") {
-            from(components["kotlin"])
+        maven {
+            name = "ProjectLocal"
+            url = uri(layout.buildDirectory.dir(".m2/repository"))
         }
     }
+}
+
+tasks.register<Zip>("archiveAllPublicationsFromProjectLocalRepository") {
+    group = "publishing"
+    dependsOn(tasks.getByName("publishAllPublicationsToProjectLocalRepository"))
+    from("${layout.buildDirectory.get()}/.m2/repository/")
 }


### PR DESCRIPTION
## Tracking

TROUP-33

## Objective

Instead of publishing directly to GitHub Packages, artifacts are 
published to a local maven repository within the CI workflow and then
uploaded as build artifacts. This change provides visibility into the
published artifacts and facilitates debugging.