### PR TITLE
[TROUP-34] Add build artifacts archive to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,15 @@ jobs:
           command: |
             ./gradlew assembleRelease
 
+      # Save build artifacts
+      - run:
+          name: Archive build artifacts
+          command: |
+            ./gradlew archiveAllPublicationsFromProjectLocalRepository
+
+      - store_artifacts:
+          path: ./troupe/build/distributions
+
       # Save lint report
       - store_artifacts:
           path: ./troupe/build/reports/lint-results-debug.html


### PR DESCRIPTION
## Tracking

TROUP-34

## Objective

Add a step to archive build artifacts generated by the `archiveAllPublicationsFromProjectLocalRepository` Gradle task.
This makes the build artifacts (ZIP files) available for download in CircleCI's artifacts tab.